### PR TITLE
!248-inaktiv-partnerrel-ne-lehessen-munkalapot-letrehozni

### DIFF
--- a/frontend/src/partners/TableListofPartners.js
+++ b/frontend/src/partners/TableListofPartners.js
@@ -28,6 +28,7 @@ export default function TableListofPartners() {
                 <Th scope="col">Név</Th>
                 <Th scope="col">Cím</Th>
                 <Th scope="col">Adószám</Th>
+                <Th scope="col">Állapot</Th>
                 <Th scope="col">Módosítás</Th>
               </Tr>
             </Thead>
@@ -41,6 +42,7 @@ export default function TableListofPartners() {
                       <Address partner={partner} />
                     </Td>
                     <Td>{partner.adoszam}</Td>
+                    <Td>{partner.enabled ? 'Aktív' : 'Inaktív'}</Td>
                     <Td>
                       <Link to={`/partners/update/${partner.partnerId}`}>
                         <EditButton />

--- a/frontend/src/worksheets/WorksheetForm.js
+++ b/frontend/src/worksheets/WorksheetForm.js
@@ -30,10 +30,12 @@ export default function WorkSheetForm({
   worksheet,
 }) {
   const { partners } = usePartners()
-  const partnersForSelect = partners?.map((partner) => ({
-    label: `${partner.nev}, a.sz.: ${partner.adoszam}`,
-    value: partner.partnerId,
-  }))
+  const partnersForSelect = partners
+    ?.filter((partner) => partner.enabled)
+    .map((partner) => ({
+      label: `${partner.nev}, a.sz.: ${partner.adoszam}`,
+      value: partner.partnerId,
+    }))
 
   const finalize = useRef(false)
   return partnersForSelect ? (


### PR DESCRIPTION
Megoldottam, hogy munkalap létrehozásakor csak az aktív partnerek jelenjenek meg a partner választásra szolgáló select-ben.
A partnerek listázásánál beraktam egy újabb oszlopot, amelyben a partner állapota (aktív/inaktív) szerepel.