### PR TITLE
!254-zart-munkalapot-ne-lehessen-szerkeszteni

### DIFF
--- a/frontend/src/worksheets/WorkSheetOperationButtons.js
+++ b/frontend/src/worksheets/WorkSheetOperationButtons.js
@@ -32,8 +32,11 @@ function WorkSheetOperationButtons({
 
   return (
     <>
-      <Link to={`/worksheets/update/${id}`}>
-        <EditButton hidden={!isEditable()} />
+      <Link
+        to={`/worksheets/update/${id}`}
+        className={`${!isEditable() && 'hidden'}`}
+      >
+        <EditButton />
       </Link>
       <FinalizeButton hidden={status !== 'CREATED'} onClick={onFinalize} />
       {isAdmin && (


### PR DESCRIPTION
A hidden class-t átraktam a gombról a link-re, így már nem kattintható a szerkesztés gomb olyan munkalapnál, amit nem szerkeszthetünk.