### PR TITLE
!261-szoveg-igazitas

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -52,3 +52,9 @@ img {
   opacity: 0.2;
   pointer-events: none;
 }
+
+@media screen and (max-width: 1200px) {
+  .layout {
+    align-items: center;
+  }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -52,9 +52,3 @@ img {
   opacity: 0.2;
   pointer-events: none;
 }
-
-@media screen and (max-width: 1200px) {
-  .layout {
-    align-items: center;
-  }
-}

--- a/frontend/src/worksheets/WorksheetListHeader.js
+++ b/frontend/src/worksheets/WorksheetListHeader.js
@@ -22,7 +22,7 @@ function WorksheetListHeader({
         </div>
       </div>
       <div className="row justify-content-between">
-        <div className="col-sm-6 d-flex flex-column layout mb-3">
+        <div className="col-sm-6 d-flex flex-column align-items-xl-start align-items-center mb-3">
           <DateRangeFilter
             startDate={startDate}
             onStartDate={onStartDate}

--- a/frontend/src/worksheets/WorksheetListHeader.js
+++ b/frontend/src/worksheets/WorksheetListHeader.js
@@ -22,7 +22,7 @@ function WorksheetListHeader({
         </div>
       </div>
       <div className="row justify-content-between">
-        <div className="col-sm-6 d-flex flex-column align-items-center mb-3">
+        <div className="col-sm-6 d-flex flex-column layout mb-3">
           <DateRangeFilter
             startDate={startDate}
             onStartDate={onStartDate}


### PR DESCRIPTION
A munkalap lista felett a "Szűrés dátum szerint" szöveg 1200px (xl) képernyőszélességtől balra igazított, alatta középre igazított. Azért 1200px, mert 1200px-ig egymás mellett van a 2 dátumszűrő input, 1200px alatt egymás alá kerülnek.